### PR TITLE
Remove url from top nav buttons to prevent 404 error

### DIFF
--- a/template-algolia/publish.js
+++ b/template-algolia/publish.js
@@ -64,7 +64,7 @@ var navigationMaster = {
   },
   namespace: {
     title: "Namespaces",
-    link: helper.getUniqueFilename("namespaces.list"),
+    // link: helper.getUniqueFilename("namespaces.list"),
     members: []
   },
   module: {

--- a/template-vanilla/publish.js
+++ b/template-vanilla/publish.js
@@ -64,7 +64,7 @@ var navigationMaster = {
   },
   namespace: {
     title: "Namespaces",
-    link: helper.getUniqueFilename("namespaces.list"),
+    // link: helper.getUniqueFilename("namespaces.list"),
     members: []
   },
   module: {


### PR DESCRIPTION
This PR removes the link in the top nav buttons.
The reason for this change is we have some 404 urls in the top nav buttons, which are not clickable anyway. These links don't bother our customers but search engine crawlers will find and complain about them.
https://apryse.slack.com/archives/C04V3RJ6WJY/p1708101543234019?thread_ts=1707946307.827379&cid=C04V3RJ6WJY
WVR-4778