### PR TITLE
Removed the href tag from the navbar

### DIFF
--- a/template-algolia/tmpl/layout.tmpl
+++ b/template-algolia/tmpl/layout.tmpl
@@ -34,7 +34,7 @@
 		<ul class="nav navbar-nav">
 			<?js this.nav.topLevelNav.forEach(function(entry){ ?>
 			<li class="dropdown">
-				<a href="<?js= entry.link ?>" class="dropdown-toggle" data-toggle="dropdown"><?js= entry.title ?><b class="caret"></b></a>
+				<a class="dropdown-toggle" data-toggle="dropdown"><?js= entry.title ?><b class="caret"></b></a>
 				<ul class="dropdown-menu <?js= that.navOptions.navType ==='inline' ? 'inline' : '' ?>">
 					<?js entry.members.forEach(function(member){ ?><li><?js= member ?></li><?js	}); ?>
 				</ul>

--- a/template-vanilla/tmpl/layout.tmpl
+++ b/template-vanilla/tmpl/layout.tmpl
@@ -32,7 +32,7 @@
 		<ul class="nav navbar-nav">
 			<?js this.nav.topLevelNav.forEach(function(entry){ ?>
 			<li class="dropdown">
-				<a href="<?js= entry.link ?>" class="dropdown-toggle" data-toggle="dropdown"><?js= entry.title ?><b class="caret"></b></a>
+				<a class="dropdown-toggle" data-toggle="dropdown"><?js= entry.title ?><b class="caret"></b></a>
 				<ul class="dropdown-menu <?js= that.navOptions.navType ==='inline' ? 'inline' : '' ?>">
 					<?js entry.members.forEach(function(member){ ?><li><?js= member ?></li><?js	}); ?>
 				</ul>


### PR DESCRIPTION
Issue:
the initial fixes comments out the link but there is a ternary operator in place see if there is a link and generate one if there is a link. This still creates 404 and the links. Commented out links are still requested from templates.

Changes:
The `tmpl` file that contains the dropdown, the href are removed. I ran the `generate-docs` with the changes in this repo and was able to remove all nav bar href.

Test:
Replace the `layout.tmpl` file in webviewer jsdoc node_modules and remove the `npm i` in the generate-docs script. Then run the script. the index.html shouldn't have any references to those 404s in the nav bar except the Apyse WebViewer title.